### PR TITLE
Alias Tailwind font tokens to font-family vars

### DIFF
--- a/tokens/build/style-dictionary.js
+++ b/tokens/build/style-dictionary.js
@@ -149,6 +149,9 @@ function inferFallbackStack(key) {
   if (/(^|[-_])mono(space)?($|[-_])/.test(normalizedKey)) {
     return "ui-monospace, monospace";
   }
+  if (/(^|[-_])sans($|[-_])/.test(normalizedKey)) {
+    return "ui-sans-serif, system-ui, sans-serif";
+  }
   if (/(^|[-_])serif($|[-_])/.test(normalizedKey)) {
     return "ui-serif, Georgia, serif";
   }


### PR DESCRIPTION
Preserve `--font-family-*` as the canonical CSS token naming surface for consistency with other font variables (for example `--font-size-*`).

Keep emitting Tailwind v4 `--font-*` variables, but map them to the canonical family tokens via `var(--font-family-*)` aliases. This keeps the generated API predictable while still enabling `font-*` utilities.

## Summary by Sourcery

Enhancements:
- Expose Tailwind v4 `--font-*` theme variables as aliases to `--font-family-*` tokens to maintain a consistent canonical font token surface.