### PR TITLE
Fix Pages base path from repo name

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Build site
         run: bun run build
         env:
-          APP_BASE_PATH: /wildside-mockup
+          APP_BASE_PATH: /${{ github.event.repository.name }}
       - name: Add SPA fallback
         run: cp dist/index.html dist/404.html
 

--- a/tests/i18n-load-path.test.ts
+++ b/tests/i18n-load-path.test.ts
@@ -4,8 +4,8 @@ import { buildFluentLoadPath, normaliseBasePath } from "../src/i18n";
 
 describe("i18n load path", () => {
   it("prefixes Fluent bundle path with BASE_URL when provided", () => {
-    const loadPath = buildFluentLoadPath("/wildside-mockup/");
-    expect(loadPath).toBe("/wildside-mockup/locales/{{lng}}/{{ns}}.ftl");
+    const loadPath = buildFluentLoadPath("/example-app/");
+    expect(loadPath).toBe("/example-app/locales/{{lng}}/{{ns}}.ftl");
   });
 
   it("normalises missing slashes on base paths", () => {


### PR DESCRIPTION
Use the repository name from the GitHub Actions context when setting APP_BASE_PATH for the production build.

This removes a stale hardcoded path that caused asset URLs to point to instead of the current repository path.

Also replace the test fixture path with a neutral example so test intent is clear and not tied to a specific repository name.

## Summary by Sourcery

Update production build configuration to derive the app base path from the GitHub repository name and align tests with a neutral example base path.

Bug Fixes:
- Fix incorrect production asset base path by removing a stale hardcoded APP_BASE_PATH value in the deploy workflow.

Tests:
- Update i18n load-path test fixture to use a neutral example base path instead of a specific repository name.