### PR TITLE
Re-enable the semantic lint gate in CI

### DIFF
--- a/.github/workflows/semantic-lint.yml
+++ b/.github/workflows/semantic-lint.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: oven-sh/setup-bun@v1
         with:
           bun-version: "latest"
+      # uv provides uvx, which `bun semantic` uses to run semgrep.
+      - uses: astral-sh/setup-uv@v7
       - run: bun install --frozen-lockfile
-      # Temporarily disabled until the semantic-class migration is complete.
-      # - run: bun semantic
+      - run: bun semantic

--- a/.github/workflows/semantic-lint.yml
+++ b/.github/workflows/semantic-lint.yml
@@ -14,6 +14,7 @@ jobs:
         with:
           bun-version: "latest"
       # uv provides uvx, which `bun semantic` uses to run semgrep.
-      - uses: astral-sh/setup-uv@v7
+      # astral-sh/setup-uv v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78
       - run: bun install --frozen-lockfile
       - run: bun semantic

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+.PHONY: check-fmt fmt lint test typecheck
+
+check-fmt:
+	bunx biome ci --linter-enabled=false --assist-enabled=false src tests tools docs package.json biome.jsonc bunfig.toml
+
+fmt:
+	bun fmt
+
+lint:
+	bun lint
+
+typecheck:
+	bun check:types
+
+test:
+	bun test

--- a/docs/building-accessible-and-responsive-progressive-web-applications.md
+++ b/docs/building-accessible-and-responsive-progressive-web-applications.md
@@ -1,8 +1,6 @@
-The Definitive Guide to Building Accessible and Responsive Progressive Web Applications
-=======================================================================================
+# The Definitive Guide to Building Accessible and Responsive Progressive Web Applications
 
-Introduction: The Convergence of Capability, Reach, and Inclusivity
--------------------------------------------------------------------
+## Introduction: The Convergence of Capability, Reach, and Inclusivity
 
 ### Defining the Modern PWA
 
@@ -36,8 +34,7 @@ In the context of this guide, progressive enhancement means:
 
 This approach ensures that the application is robust and reaches the widest possible audience. It inherently supports both responsiveness---by starting with a simple, mobile-friendly layout and enhancing it for larger screens---and accessibility---by ensuring the fundamental content and structure are semantic and available to assistive technologies before any complex scripting is applied.^2^
 
-Section 1: The Architectural Foundation of a Progressive Web App
-----------------------------------------------------------------
+## Section 1: The Architectural Foundation of a Progressive Web App
 
 To be recognized by a browser as an installable application with native-like capabilities, a standard web application must incorporate several key architectural components. These components, governed by web standards, provide the necessary metadata and client-side logic that transform a website into a PWA.
 
@@ -154,8 +151,7 @@ The rationale for this requirement is to mitigate the risk of man-in-the-middle 
 
 For development purposes, browsers make an exception and treat `http://localhost` as a secure context, allowing developers to test PWA features locally without needing to set up a self-signed certificate.^4^ However, for any publicly deployed PWA, HTTPS is mandatory. Services like Let's Encrypt provide free SSL/TLS certificates, making it straightforward for developers to secure their applications.^4^
 
-Section 2: Mastering the Service Worker: Lifecycle and Caching Strategies
--------------------------------------------------------------------------
+## Section 2: Mastering the Service Worker: Lifecycle and Caching Strategies
 
 The service worker is not a simple script; it operates under a distinct and carefully designed lifecycle that governs how it is installed, updated, and how it takes control of pages. Understanding this lifecycle is paramount for implementing reliable caching and update mechanisms.
 
@@ -305,8 +301,7 @@ A single caching strategy is rarely sufficient for an entire application. A robu
 
 Data synthesized from sources: ^26^
 
-Section 3: Engineering a Responsive, Multi-Device User Interface
-----------------------------------------------------------------
+## Section 3: Engineering a Responsive, Multi-Device User Interface
 
 A Progressive Web App must provide an excellent user experience on any device, from a small mobile phone to a widescreen desktop monitor. This adaptability is achieved through the principles and techniques of Responsive Web Design (RWD), which are not just a best practice but a core requirement for a successful PWA.^1^
 
@@ -424,8 +419,7 @@ HTML
 
 ```
 
-Section 4: Building an Inclusive Application: A Web Standards Approach to Accessibility
----------------------------------------------------------------------------------------
+## Section 4: Building an Inclusive Application: A Web Standards Approach to Accessibility
 
 Accessibility (often abbreviated as a11y) is the practice of ensuring that websites and applications are designed and developed so that people with disabilities can use them. For a PWA, which aims to provide a high-quality, app-like experience, inclusivity is not an optional extra; it is an essential component of its design and engineering.
 
@@ -525,8 +519,7 @@ The sequence in which elements receive keyboard focus must be logical and predic
 
 It must always be visually apparent which element on the page currently has keyboard focus.^69^ Browsers provide a default focus indicator (typically a blue outline), but this is often removed by developers for aesthetic reasons using CSS like `*:focus { outline: none; }`. This is a common and severe accessibility failure.^69^ If the default focus indicator is removed, it is the developer's responsibility to provide a clear, high-contrast replacement.^71^ The CSS pseudo-class `:focus-visible` provides a modern solution, allowing developers to show a custom focus style only for keyboard-initiated focus, while hiding it for mouse clicks, satisfying both aesthetic and accessibility requirements.^71^
 
-Section 5: Advanced Patterns: Synthesizing PWA, RWD, and Accessibility
-----------------------------------------------------------------------
+## Section 5: Advanced Patterns: Synthesizing PWA, RWD, and Accessibility
 
 This section delves into advanced topics where the principles of PWA technology, responsive design, and accessibility converge, requiring a holistic approach to solve complex challenges in the modern web application landscape.
 
@@ -599,8 +592,7 @@ The Background Sync API provides the technical foundation for the "queueing acti
 
 For tasks that need to happen periodically, such as a news app pre-fetching the latest articles every morning, the **Periodic Background Sync API** can be used. This allows the app to register a task to run at regular intervals, which the browser will execute in the background when conditions are optimal (e.g., the device is on Wi-Fi and has sufficient battery).^92^
 
-Section 6: Auditing, Testing, and Continuous Improvement
---------------------------------------------------------
+## Section 6: Auditing, Testing, and Continuous Improvement
 
 Building an accessible and responsive PWA is an iterative process. A commitment to rigorous testing and continuous improvement is essential to ensure a high-quality final product. This involves a combination of automated auditing tools and indispensable manual testing procedures.
 
@@ -660,34 +652,34 @@ This checklist provides a structured framework for conducting a comprehensive qu
 | --- | --- | --- | --- |
 | **PWA Installability** | Manifest has `name`/`short_name`, `icons` (192, 512), `start_url`, `display`. | Automated | Lighthouse PWA Audit |
 |\
- | Site is served over HTTPS. | Automated | Lighthouse PWA Audit |
+| Site is served over HTTPS. | Automated | Lighthouse PWA Audit |
 |\
- | Registers a service worker. | Automated | Lighthouse PWA Audit |
+| Registers a service worker. | Automated | Lighthouse PWA Audit |
 | **PWA Reliability** | `start_url` responds with a 200 status code when offline. | Automated | Lighthouse PWA Audit |
 |\
- | Page provides a custom offline fallback experience. | Manual | DevTools Offline Mode |
+| Page provides a custom offline fallback experience. | Manual | DevTools Offline Mode |
 | **Perceivable** | All non-decorative images have descriptive `alt` text. | Manual | Code Review, Screen Reader |
 |\
- | Color contrast for text and UI components meets WCAG AA levels. | Automated | Lighthouse, DevTools Inspector |
+| Color contrast for text and UI components meets WCAG AA levels. | Automated | Lighthouse, DevTools Inspector |
 |\
- | Content reflows to a single column at 320px width without horizontal scroll. | Manual | Browser Resizing |
+| Content reflows to a single column at 320px width without horizontal scroll. | Manual | Browser Resizing |
 | **Operable** | All interactive functionality is operable with a keyboard. | Manual | Keyboard-Only Testing |
 |\
- | A visible focus indicator is always present for the active element. | Manual | Keyboard-Only Testing |
+| A visible focus indicator is always present for the active element. | Manual | Keyboard-Only Testing |
 |\
- | Focus order is logical and follows the visual layout. | Manual | Keyboard-Only Testing |
+| Focus order is logical and follows the visual layout. | Manual | Keyboard-Only Testing |
 |\
- | No keyboard traps exist, especially in modals or complex widgets. | Manual | Keyboard-Only Testing |
+| No keyboard traps exist, especially in modals or complex widgets. | Manual | Keyboard-Only Testing |
 |\
- | Focus is correctly managed on client-side route changes. | Manual | Keyboard & Screen Reader |
+| Focus is correctly managed on client-side route changes. | Manual | Keyboard & Screen Reader |
 | **Understandable** | Page `title` is updated on every client-side route change. | Manual | Browser Tab, Screen Reader |
 |\
- | A logical heading structure (`<h1>`-`<h6>`) is used. | Manual | Code Review, Screen Reader |
+| A logical heading structure (`<h1>`-`<h6>`) is used. | Manual | Code Review, Screen Reader |
 |\
- | Dynamic content changes and status messages are announced to screen readers. | Manual | Screen Reader Testing |
+| Dynamic content changes and status messages are announced to screen readers. | Manual | Screen Reader Testing |
 | **Robust** | HTML is well-formed and uses semantic elements where appropriate. | Manual | Code Review, W3C Validator |
 |\
- | ARIA roles, states, and properties are used correctly on custom components. | Manual | Code Review, Accessibility Inspector |
+| ARIA roles, states, and properties are used correctly on custom components. | Manual | Code Review, Accessibility Inspector |
 
 Data synthesized from sources: ^69^
 
@@ -695,8 +687,7 @@ Data synthesized from sources: ^69^
 
 The launch of a PWA is not the end of the development process but the beginning of its lifecycle. The service worker update mechanism means that maintaining and improving the application is a continuous process. It is crucial to integrate the auditing and testing practices outlined above into the ongoing development workflow. Automated checks should be part of a continuous integration (CI) pipeline, and manual accessibility reviews should be a standard part of the process for every new feature. By embracing this cycle of development, testing, and refinement, teams can ensure their Progressive Web Applications remain capable, adaptable, and inclusive for all users over the long term.
 
-Conclusion
-----------
+## Conclusion
 
 The creation of a modern Progressive Web Application is an exercise in synthesis. It demands the integration of three distinct but deeply interwoven disciplines: the robust, offline-first architecture of PWAs; the fluid, device-agnostic principles of Responsive Web Design; and the inclusive, human-centered standards of Web Accessibility. A PWA that excels in only one or two of these areas is incomplete. True excellence is achieved only when an application is simultaneously reliable, adaptable, and accessible to all.
 

--- a/docs/daisyui-v5-guide.md
+++ b/docs/daisyui-v5-guide.md
@@ -1,10 +1,9 @@
 ---
-description: daisyUI 5
+## description: daisyUI 5
 alwaysApply: true
 applyTo: "**"
 downloadedFrom: https://daisyui.com/llms.txt
 version: 5.3.x
----
 
 # daisyUI 5
 daisyUI 5 is a CSS library for Tailwind CSS 4
@@ -21,11 +20,14 @@ daisyUI 5 provides class names for common UI components
 2. `tailwind.config.js` file is deprecated in Tailwind CSS v4. do not use `tailwind.config.js`. Tailwind CSS v4 only needs `@import "tailwindcss";` in the CSS file if it's a node dependency.
 3. daisyUI 5 can be installed using `npm i -D daisyui@latest` and then adding `@plugin "daisyui";` to the CSS file
 4. daisyUI is suggested to be installed as a dependency but if you really want to use it from CDN, you can use Tailwind CSS and daisyUI CDN files:
+
 ```html
 <link href="https://cdn.jsdelivr.net/npm/daisyui@5" rel="stylesheet" type="text/css" />
 <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
 ```
+
 5. A CSS file with Tailwind CSS and daisyUI looks like this (if it's a node dependency)
+
 ```css
 @import "tailwindcss";
 @plugin "daisyui";
@@ -1742,4 +1744,3 @@ Validator class changes the color of form elements to error or success based on 
 
 #### Rules
 - Use with `input`, `select`, `textarea`
-

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1,0 +1,34 @@
+# Developers guide
+
+This guide records the local and Continuous Integration (CI) checks developers
+are expected to run before submitting changes. It complements the project
+scripts in `package.json` and the deeper design notes in `docs/`.
+
+## Semantic lint gate
+
+The `semantic-lint` CI workflow runs the `bun semantic` script. This is the
+required lint gate for pull requests, and it must exercise the same semantic
+checks locally and in CI:
+
+- Biome checks over `src`, `tests`, `tools`, and `docs`.
+- Class-list length checks for Tailwind utility strings.
+- Near-duplicate Tailwind class checks.
+- Semgrep rules from `tools/semgrep-semantic.yml`.
+- Stylelint checks over `src/**/*.css`.
+
+Run the gate locally with:
+
+```bash
+bun semantic
+```
+
+The semantic gate depends on `uvx` because the Semgrep step is executed through
+`uvx semgrep`. Local development environments therefore need `uv` installed and
+available on `PATH`. The CI workflow installs that dependency with
+`astral-sh/setup-uv` before running `bun semantic`; the action is pinned to a
+full commit SHA, with the upstream release tag retained in a comment for
+upgrade traceability.
+
+When changing the workflow, keep `tests/semantic-lint-workflow.test.ts` in sync.
+That smoke test verifies that CI still installs `uvx` support before invoking
+the semantic gate and that the third-party action remains pinned.

--- a/docs/documentation-style-guide.md
+++ b/docs/documentation-style-guide.md
@@ -8,9 +8,9 @@ these rules to keep the documentation clear and consistent for developers.
 - Use British English based on the
   [Oxford English Dictionary](https://public.oed.com/) (en-GB-oxendict):
   - suffix -ize in words like _realize_ and _organization_ instead of
-     -ise endings,
+    -ise endings,
   - suffix ‑lyse in words not traced to the Greek ‑izo, ‑izein suffixes,
-     such as _analyse_, _paralyse_ and _catalyse_,
+    such as _analyse_, _paralyse_ and _catalyse_,
   - suffix -our in words such as _colour_, _behaviour_ and _neighbour_,
   - suffix -re in words such as _calibre_, _centre_ and fibre,
   - double "l" in words such as _cancelled_, _counsellor_ and _cruellest_,
@@ -82,7 +82,7 @@ contents of the manual.
   they do not execute during documentation tests.
 - Put function attributes after the doc comment.
 
-```rust
+````rust
 /// Returns the sum of `a` and `b`.
 ///
 /// # Parameters
@@ -101,7 +101,7 @@ contents of the manual.
 pub fn add(a: i32, b: i32) -> i32 {
     a + b
 }
-```
+````
 
 ## Diagrams and images
 

--- a/docs/enforcing-semantic-tailwind-best-practice.md
+++ b/docs/enforcing-semantic-tailwind-best-practice.md
@@ -9,7 +9,7 @@
 ## 0) Scope & Philosophy
 
 - **Files:** `.tsx`, `.html`, `.css` (Tailwind v4 + DaisyUI v5).
-- **Primary tool:** **BiomeJS** linter with **GritQL** rules (diagnostics only).  
+- **Primary tool:** **BiomeJS** linter with **GritQL** rules (diagnostics only).
 - **Fallbacks:**
   - **Stylelint** — design‑token enforcement, CSS `@apply` hygiene, units/specificity.
   - **Semgrep** — simple cross‑language regex/AST patterns (HTML/JSX) where easier than GritQL.
@@ -271,13 +271,13 @@ These heuristics focus on **structural intent** rather than raw class similarity
 
 ### 1) “Div/span soup” (utility-only wrapper chains)
 - **Signal**: Two or more nested `<div>`/`<span>` nodes whose only attribute is a utility-heavy `className` (no `role`, `aria-*`, `id`, `data-*`, event handlers).
-- **Meaning**: The wrapper is expressing a *layout concept* (stack, cluster, surface) without naming it.
+- **Meaning**: The wrapper is expressing a _layout concept_ (stack, cluster, surface) without naming it.
 - **Action**: Warn and suggest extracting a named container class (e.g. `.stack`, `.cluster`, `.card__body`) via `@apply`.
 - **Implementation notes**: GritQL rule that walks parent/child utility-only nodes and fires when depth ≥ 2; fallback AST walker if needed.
 
 ### 2) Landmarks and slot semantics
 - **Signal**: Utility-only child elements inside semantic regions such as `<nav>`, `<header>`, `<ul>`, `<form>`.
-- **Meaning**: These are *slots* (navigation links, menu items, form controls) that deserve a named semantic class.
+- **Meaning**: These are _slots_ (navigation links, menu items, form controls) that deserve a named semantic class.
 - **Action**: Suggest contextual names like `.nav__link`, `.nav__link--active`, `.menu__item`, `.form__label`.
 - **Implementation notes**: GritQL ancestor constraint rules that tailor the suggestion to the enclosing landmark.
 
@@ -532,7 +532,7 @@ semantic fixes over ad hoc opt-outs.
 **Q: Will `@apply` bloat CSS?**  
 A: We extract only repeated patterns. Tailwind still tree‑shakes class‑based styles; the few semantic classes you add are minimal and intentionally reused.
 
-**Q: When is it *okay* to keep utilities inline?**  
+**Q: When is it _okay_ to keep utilities inline?**  
 A: One‑offs, quick prototypes, and tiny adjustments local to a component. Once the same chunk appears twice, prefer extracting it.
 
 **Q: How strict are thresholds?**  
@@ -542,8 +542,8 @@ A: Configurable. Start with `repeatMinClasses=4`, `repeatMinOccurrences=2`. Tigh
 
 ## 15) Ready-to-run checklist
 
-1) Add files: `tools/grit/*.grit`, `tools/semantic-lint.config.json`, `tools/stylelint.config.cjs`, `tools/semgrep-semantic.yml`.  
-2) Wire **Biome** plugin or wrapper to execute Grit rules (paths above).  
-3) Add **`semantic.css`** and begin extracting repeated patterns with `@apply`.  
-4) Add **`lint:semantic`** script and the CI workflow.  
+1) Add files: `tools/grit/*.grit`, `tools/semantic-lint.config.json`, `tools/stylelint.config.cjs`, `tools/semgrep-semantic.yml`.
+2) Wire **Biome** plugin or wrapper to execute Grit rules (paths above).
+3) Add **`semantic.css`** and begin extracting repeated patterns with `@apply`.
+4) Add **`lint:semantic`** script and the CI workflow.
 5) Iterate on thresholds, allowlist prefixes, and rule messages as the team gains patterns.

--- a/docs/high-velocity-accessibility-first-component-testing.md
+++ b/docs/high-velocity-accessibility-first-component-testing.md
@@ -20,7 +20,7 @@ Unfortunately, Bun’s test runner **does not yet support** the more standards-c
 
 - The only viable alternative (JSDOM) isn’t supported in Bun’s native runner.
 
-In summary, **Bun alone cannot run component-level accessibility scans** today. This impasse is not a matter of configuration or minor bug; it’s a fundamental limitation of the current Bun + Happy DOM pairing. We must therefore adjust our strategy to retain Bun’s performance benefits *and* enable `axe-core` scans through other means. The solution is a **hybrid testing approach**: run most tests in Bun for speed, but outsource accessibility-specific tests to a Node.js environment that supports JSDOM.
+In summary, **Bun alone cannot run component-level accessibility scans** today. This impasse is not a matter of configuration or minor bug; it’s a fundamental limitation of the current Bun + Happy DOM pairing. We must therefore adjust our strategy to retain Bun’s performance benefits _and_ enable `axe-core` scans through other means. The solution is a **hybrid testing approach**: run most tests in Bun for speed, but outsource accessibility-specific tests to a Node.js environment that supports JSDOM.
 
 ### 1.2 A Hybrid Solution: Node.js + JSDOM for A11y Scans
 
@@ -159,7 +159,7 @@ test('Button has no accessibility violations and is properly labelled', async ()
 `
 ```
 
-In this example, when run in a Node+JSDOM environment, the `Button` component is rendered off-screen and scanned. The test will fail if, for instance, the `<Button>` component is missing an accessible name or has ARIA attributes misused. By including a Testing Library query (`getByRole('button', { name: /click me/i })`), we double-verify that the component is not only *free of axe-detectable violations* but also that it adheres to expected accessibility APIs (here, that a button with text "Click Me" indeed yields an element with role `button` and that label).
+In this example, when run in a Node+JSDOM environment, the `Button` component is rendered off-screen and scanned. The test will fail if, for instance, the `<Button>` component is missing an accessible name or has ARIA attributes misused. By including a Testing Library query (`getByRole('button', { name: /click me/i })`), we double-verify that the component is not only _free of axe-detectable violations_ but also that it adheres to expected accessibility APIs (here, that a button with text "Click Me" indeed yields an element with role `button` and that label).
 
 We apply this pattern to all interactive components. A more complex example is a **Modal** component which might be hidden or shown based on props:
 
@@ -204,9 +204,9 @@ Having the right tools is only half the battle. We also enforce **strict convent
 
 - **Use of Accessible Queries:** Tests must interact with the rendered DOM the same way a user or assistive technology would – i.e. by using accessible labels, roles, and text content. We forbid selecting elements by obscure hooks or internal IDs whenever a semantic alternative exists. In practice, this means favoring Testing Library queries like `getByRole`, `getByLabelText`, or `getByText` over queries like `querySelector('[data-testid="..."]')`. If our tests cannot find an element by a meaningful label or role, that’s a red flag that the component might not be accessible.
 
-*Policy:* The use of `data-testid` (or similar testing-only attributes) is considered a last resort. In code review, any test that uses a test ID must justify why a role or label could not be used instead. Often, the remedy is to improve the component (e.g. add an `aria-label` or proper text) such that a more user-centric query becomes possible. This policy creates a virtuous cycle: it pushes developers to build components with accessibility in mind (so they are easily testable), and it makes the tests more robust by tying them to user-visible strings and roles.
+_Policy:_ The use of `data-testid` (or similar testing-only attributes) is considered a last resort. In code review, any test that uses a test ID must justify why a role or label could not be used instead. Often, the remedy is to improve the component (e.g. add an `aria-label` or proper text) such that a more user-centric query becomes possible. This policy creates a virtuous cycle: it pushes developers to build components with accessibility in mind (so they are easily testable), and it makes the tests more robust by tying them to user-visible strings and roles.
 
-*Automation:* Biome loads the `tools/grit/rule-testing-*.grit` patterns, which emit the
+_Automation:_ Biome loads the `tools/grit/rule-testing-*.grit` patterns, which emit the
 `test/no-testid-selectors`, `test/no-queryselector`,
 `test/prefer-byrole-for-actions`, and `test/no-raw-dom-lookup` diagnostics for
 test files. These rules error on any `*ByTestId` lookup (or raw
@@ -217,7 +217,7 @@ Playwright. If a semantic selector is genuinely impossible, add an
 `// biome-ignore lint/test/no-testid-selectors` suppression so reviewers can
 see the trade-off.
 
-*Example:* In the `GlobalControls` component test, instead of selecting a toggle button by an ID or class, we query it by its accessible name:
+_Example:_ In the `GlobalControls` component test, instead of selecting a toggle button by an ID or class, we query it by its accessible name:
 
 ```
 tsxCopy code`const displayToggle = mountNode.querySelector("button[aria-label='Switch to Full View']");
@@ -290,7 +290,7 @@ However, we must be strategic to avoid slowing down the suite. Running a full ax
 
 - **After major UI transitions:** For example, after opening a modal, after navigating to a new page, after triggering a form validation that reveals errors, etc. These are points where new content appears or state significantly changes, warranting a re-check.
 
-- **Scope the scan to changed regions:** Using `AxeBuilder.include(selector)` we can limit analysis to specific parts of the DOM. For instance, after opening a modal, we can scan *only* the modal dialog element instead of the entire page (which saves time and focuses results).
+- **Scope the scan to changed regions:** Using `AxeBuilder.include(selector)` we can limit analysis to specific parts of the DOM. For instance, after opening a modal, we can scan _only_ the modal dialog element instead of the entire page (which saves time and focuses results).
 
 **Example – Modal Workflow:** Consider a test of an e-commerce flow where clicking "Add to Cart" opens a dialog. We can write:
 
@@ -369,7 +369,7 @@ We do similar tests for menus, dialogs, and other composite components:
 
 - Ensuring **Escape** closes dialogs or dropdowns when focused inside them.
 
-- Verifying there are no **keyboard traps**: focus should never get stuck in a loop or lost off-screen. For modals, we *want* focus trap within the modal while it’s open (so Tab doesn’t go behind the modal), but when the modal closes, focus should return to a sensible place (often the button that opened it).
+- Verifying there are no **keyboard traps**: focus should never get stuck in a loop or lost off-screen. For modals, we _want_ focus trap within the modal while it’s open (so Tab doesn’t go behind the modal), but when the modal closes, focus should return to a sensible place (often the button that opened it).
 
 These tests give us confidence that a sighted keyboard user or a visually impaired user using keyboard + screen reader can navigate and operate the app fully.
 
@@ -618,7 +618,7 @@ We use Playwright and our Node tests’ reporting capabilities to output machine
 
 Our team’s workflow is then: if a test fails, especially an accessibility one, the engineer can download the report artifact and see exactly what failed – for example, a Playwright trace showing that after clicking a button, the focus did not move as expected, or an axe report highlighting a missing form label.
 
-Finally, we maintain a **culture of accessibility ownership**. Failing tests are not just turned green by updating the tests – the expectation is to *fix the underlying issue*. Because the tests are designed to catch real problems, the correct response to a failure is usually to correct the component or page (e.g., add the missing `aria-label`, adjust the color contrast in CSS, fix the focus logic in JavaScript).
+Finally, we maintain a **culture of accessibility ownership**. Failing tests are not just turned green by updating the tests – the expectation is to _fix the underlying issue_. Because the tests are designed to catch real problems, the correct response to a failure is usually to correct the component or page (e.g., add the missing `aria-label`, adjust the color contrast in CSS, fix the focus logic in JavaScript).
 
 To help manage this, we integrate severity tagging:
 
@@ -722,8 +722,8 @@ By modernizing the original design to use **Bun for speed** and a **Node assist 
 
 ## Footnotes
 
-- *Happy DOM issue tracker – documented incompatibility of `Node.isConnected` implementation with axe-core’s expectations.* ↩
+- _Happy DOM issue tracker – documented incompatibility of `Node.isConnected` implementation with axe-core’s expectations._ ↩
 
-- *Bun GitHub issue #3554 – tracking request for JSDOM support in Bun’s test runner (unresolved as of 2025).* ↩
+- _Bun GitHub issue #3554 – tracking request for JSDOM support in Bun’s test runner (unresolved as of 2025)._ ↩
 
-- *Deque `axe-core` documentation – notes on JSDOM support and rules like color-contrast being inapplicable in headless DOM.* ↩
+- _Deque `axe-core` documentation – notes on JSDOM support and rules like color-contrast being inapplicable in headless DOM._ ↩

--- a/docs/pure-accessible-and-localizable-react-components.md
+++ b/docs/pure-accessible-and-localizable-react-components.md
@@ -855,9 +855,9 @@ user settings.
 **Step-by-Step Implementation:**
 
 1. **Foundation (Behavioral Layer):** The component's structure is defined
-    using Radix UI primitives. `AlertDialog.Root` creates the modal context,
-    and `Form.Root` provides the accessible form structure. This initial step
-    produces an unstyled but fully functional and accessible component.
+   using Radix UI primitives. `AlertDialog.Root` creates the modal context,
+   and `Form.Root` provides the accessible form structure. This initial step
+   produces an unstyled but fully functional and accessible component.
 
     ```typescript
     // UserSettingsModal.view.tsx (initial structure)
@@ -881,12 +881,12 @@ user settings.
     ```
 
 2. **Styling (Presentational Layer):** DaisyUI and Tailwind CSS classes are
-    applied to the Radix primitives. `AlertDialog.Content` gets `modal-box`,
-    `Form.Field` gets `form-control`, and so on. Responsive prefixes like `md:`
-    are used to adjust layout for larger screens.
+   applied to the Radix primitives. `AlertDialog.Content` gets `modal-box`,
+   `Form.Field` gets `form-control`, and so on. Responsive prefixes like `md:`
+   are used to adjust layout for larger screens.
 
 3. **State & Logic (Hook Layer):** A `useUserSettingsForm` hook is created to
-    encapsulate all logic.
+   encapsulate all logic.
 
     - **Localization:** The hook begins by calling
       `useTranslation('userProfile')` to get the `t` function. It prepares all
@@ -940,10 +940,10 @@ user settings.
     ```
 
 4. **Connecting the View (Synthesis):** The final `UserSettingsModal.view.tsx`
-    is a pure presentational component. It is wrapped in `React.memo` and
-    receives all its data and callbacks from the `useUserSettingsForm` hook via
-    props. It has no internal logic, no direct calls to state management or
-    data fetching libraries, and no direct knowledge of the i18n system.
+   is a pure presentational component. It is wrapped in `React.memo` and
+   receives all its data and callbacks from the `useUserSettingsForm` hook via
+   props. It has no internal logic, no direct calls to state management or
+   data fetching libraries, and no direct knowledge of the i18n system.
 
 This architecture achieves the ultimate separation of concerns. The view
 component is "language-agnostic"; it simply renders the strings it is given.

--- a/docs/react-tailwind-with-bun.md
+++ b/docs/react-tailwind-with-bun.md
@@ -136,7 +136,7 @@ Bun bundles HTML, TS/JS, CSS assets. Use `--production` for minification and tre
 bun build ./index.html --production --outdir=dist
 ```
 
-You’ll get a *fully bundled* `dist/` directory ready to host anywhere.
+You’ll get a _fully bundled_ `dist/` directory ready to host anywhere.
 
 ---
 

--- a/docs/semantic-tailwind-with-daisyui-best-practice.md
+++ b/docs/semantic-tailwind-with-daisyui-best-practice.md
@@ -42,7 +42,7 @@ If you keep your components in unusual places, add explicit sources:
 2. **Headless behaviour**: Radix primitives provide accessibility and state via attributes like `data-state`, `data-disabled`, `aria-expanded`.
 3. **Component classes**: daisyUI gives structural styles (`btn`, `card`, `input`, `menu`, `alert`, …) and colour roles (`btn-primary`, `bg-base-100`, …).
 4. **Utilities**: Tailwind v4 utilities for spacing, layout, visibility, state variants, container queries, etc.
-5. **Semantic wrappers**: project-specific *meaningful* classes (e.g., `.cta`, `.product-card`) implemented using Tailwind’s `@utility` (and selective `@apply`) to encode intent and keep markup tidy where repetition would otherwise explode.
+5. **Semantic wrappers**: project-specific _meaningful_ classes (e.g., `.cta`, `.product-card`) implemented using Tailwind’s `@utility` (and selective `@apply`) to encode intent and keep markup tidy where repetition would otherwise explode.
 
 The cascade should flow so that **inline utilities win** over broad component styles. That keeps local adjustments easy.
 
@@ -98,7 +98,7 @@ Use them in markup where repetition would otherwise get silly:
 <button class="cta/ghost">Learn more</button>
 ```
 
-> **Rule of thumb:** If a class name describes *what the thing is* to the business or user, keep it. If it describes *how it looks* (e.g., `.blue-btn`, `.mt-4`), prefer utilities.
+> **Rule of thumb:** If a class name describes _what the thing is_ to the business or user, keep it. If it describes _how it looks_ (e.g., `.blue-btn`, `.mt-4`), prefer utilities.
 
 ---
 
@@ -193,7 +193,7 @@ Example for a menu item:
 ## 6) `@apply` vs `@utility` (v4 reality)
 
 - Use **`@apply`** to inline Tailwind **utilities** into CSS when you must style third‑party DOM, author CSS Modules / Vue `<style>` blocks, or reduce repetition inside a semantic wrapper. Pair it with `@reference` when applying inside component‑scoped styles.
-- Use **`@utility`** to register a **custom utility** (or a small family of them) that participates in Tailwind’s variant system (`hover:`, `md:`, `data-[state=…]:`, etc.). Prefer this for *project‑specific shorthands* that you want to behave like first‑class utilities.
+- Use **`@utility`** to register a **custom utility** (or a small family of them) that participates in Tailwind’s variant system (`hover:`, `md:`, `data-[state=…]:`, etc.). Prefer this for _project‑specific shorthands_ that you want to behave like first‑class utilities.
 
 Examples:
 
@@ -215,7 +215,7 @@ Examples:
 ### 6.1 Encode state with selectors, not variant `@apply`
 
 Tailwind v4 only inlines **plain utilities** when you call `@apply`. Variant
-helpers such as `hover:`, `group-…`, or `data-[state=…]:…` are *not* expanded,
+helpers such as `hover:`, `group-…`, or `data-[state=…]:…` are _not_ expanded,
 which means the rule below will quietly drop the interactive parts:
 
 ```css
@@ -226,7 +226,7 @@ which means the rule below will quietly drop the interactive parts:
 ```
 
 Instead, combine `@apply` (for the static bits) with explicit selectors for
-stateful styles. This keeps the markup clean *and* ensures Radix data attributes
+stateful styles. This keeps the markup clean _and_ ensures Radix data attributes
 toggle the look correctly:
 
 ```css
@@ -258,7 +258,7 @@ Markup stays semantic:
 >
 > **Ordering hint:** When your markup keeps Tailwind utilities (e.g. `bg-base-200/60`
 > or `text-base-content/70`) alongside a semantic class, place the stateful
-> selectors in the `@layer utilities` block so they compile *after* the inline
+> selectors in the `@layer utilities` block so they compile _after_ the inline
 > utilities. Otherwise those utilities will win the cascade and your state
 > styles will never show up.
 
@@ -311,12 +311,12 @@ export function PlanCard() {
 
 ## 9) Checklist (fast sanity)
 
-- [ ] Semantic element first; ARIA as clarifier.
-- [ ] Prefer daisyUI tokens (`bg-primary`, `rounded-box`, `text-base-content`) for theme‑aware styles.
-- [ ] Use Tailwind utilities for per‑instance polish and state.
-- [ ] Create semantic wrappers only for reused intent; implement with `@utility`/`@apply` (utilities only).
-- [ ] Target Radix state via `data-[state=…]`, `data-[highlighted]`, `data-[disabled]`.
-- [ ] Keep specificity low; let utilities win locally.
+- [] Semantic element first; ARIA as clarifier.
+- [] Prefer daisyUI tokens (`bg-primary`, `rounded-box`, `text-base-content`) for theme‑aware styles.
+- [] Use Tailwind utilities for per‑instance polish and state.
+- [] Create semantic wrappers only for reused intent; implement with `@utility`/`@apply` (utilities only).
+- [] Target Radix state via `data-[state=…]`, `data-[highlighted]`, `data-[disabled]`.
+- [] Keep specificity low; let utilities win locally.
 
 ---
 
@@ -428,9 +428,9 @@ Tailwind v4 lets you reference custom properties in arbitrary values without wri
 <button class="ring-(--color-primary) ring-2 outline-(--color-primary)">Focus</button>
 ```
 
-### 11.5 Project utilities that *feel* first‑class
+### 11.5 Project utilities that _feel_ first‑class
 
-Where you need semantic *wrappers*, register them as **custom utilities** so they inherit variants (`hover:`, `md:`, `data-[state=...]`) like any Tailwind class.
+Where you need semantic _wrappers_, register them as **custom utilities** so they inherit variants (`hover:`, `md:`, `data-[state=...]`) like any Tailwind class.
 
 ```css
 /* A semantic CTA built from tokens (no component class @apply) */
@@ -534,4 +534,4 @@ If you want matching Tailwind utilities, back them with `@theme`:
 - In component‑scoped styles, add `@reference "../app.css";` before using `@apply` so Tailwind can resolve your tokens.
 - Don’t `@apply` plugin component classes (`btn`, `card`); compose them in markup or rebuild with tokens.
 
-**Bottom line:** put *values* in `@theme`, map *roles* to daisyUI tokens, and style *states* with Radix data‑attrs + utility variants. One vocabulary, zero fights.
+**Bottom line:** put _values_ in `@theme`, map _roles_ to daisyUI tokens, and style _states_ with Radix data‑attrs + utility variants. One vocabulary, zero fights.

--- a/docs/tailwind-v3-v4-migration-guide.md
+++ b/docs/tailwind-v3-v4-migration-guide.md
@@ -3,9 +3,9 @@ Here is what you need to know about Tailwind CSS v4 (May 2025)
 ### I. Core Architecture & Performance
 
 1.  **New Engine - Performance First:**
-    *   V4 ships with a completely rewritten engine. Expect drastically reduced build times – typically sub-10ms for most projects, even large ones often under 100ms. This is achieved by more efficiently parsing sources and generating CSS on-demand.
+    -   V4 ships with a completely rewritten engine. Expect drastically reduced build times – typically sub-10ms for most projects, even large ones often under 100ms. This is achieved by more efficiently parsing sources and generating CSS on-demand.
 2.  **CSS-First Configuration via `@theme`:**
-    *   The primary configuration mechanism shifts from `tailwind.config.js` (for theme values) to your main CSS file using the `@theme` directive.
+    -   The primary configuration mechanism shifts from `tailwind.config.js` (for theme values) to your main CSS file using the `@theme` directive.
         ```css
         /* app.css */
         @import "tailwindcss";
@@ -17,80 +17,80 @@ Here is what you need to know about Tailwind CSS v4 (May 2025)
           --spacing: 0.25rem; /* Base for numeric spacing utilities */
         }
         ```
-    *   Theme values are defined as CSS custom properties (variables). Tailwind uses these to generate corresponding utility classes (e.g., `font-sans`, `bg-brand-500`, `lg:p-(--spacing-4)`) and also makes these variables globally available for use in custom CSS or arbitrary values (e.g., `var(--color-brand-500)`).
-    *   The default theme is still provided but can be extended, overridden, or entirely replaced using this CSS-native approach. For instance, `--color-*: initial;` within `@theme` will remove all default color utilities, allowing a fully custom palette.
+    -   Theme values are defined as CSS custom properties (variables). Tailwind uses these to generate corresponding utility classes (e.g., `font-sans`, `bg-brand-500`, `lg:p-(--spacing-4)`) and also makes these variables globally available for use in custom CSS or arbitrary values (e.g., `var(--color-brand-500)`).
+    -   The default theme is still provided but can be extended, overridden, or entirely replaced using this CSS-native approach. For instance, `--color-*: initial;` within `@theme` will remove all default color utilities, allowing a fully custom palette.
 3.  **Modern CSS Baseline:**
-    *   Targets **Safari 16.4+, Chrome 111+, Firefox 128+**. This is non-negotiable as v4 relies on features like `@property`, `color-mix()`, and modern cascade layers. Older browser support requires sticking to v3.4.
-    *   The default color palette leverages OKLCH for more vibrant, perceptually uniform colors out-of-the-box.
+    -   Targets **Safari 16.4+, Chrome 111+, Firefox 128+**. This is non-negotiable as v4 relies on features like `@property`, `color-mix()`, and modern cascade layers. Older browser support requires sticking to v3.4.
+    -   The default color palette leverages OKLCH for more vibrant, perceptually uniform colors out-of-the-box.
 
 ### II. Build & Integration
 
 1.  **Simplified Imports:**
-    *   The `@tailwind base; @tailwind components; @tailwind utilities;` directives are deprecated. A single `@import "tailwindcss";` now handles the injection of base styles (Preflight), theme variables, and utilities into their respective cascade layers.
+    -   The `@tailwind base; @tailwind components; @tailwind utilities;` directives are deprecated. A single `@import "tailwindcss";` now handles the injection of base styles (Preflight), theme variables, and utilities into their respective cascade layers.
 2.  **Modular Tooling Packages:**
-    *   **CLI:** `npx @tailwindcss/cli ...` (package: `@tailwindcss/cli`)
-    *   **PostCSS Plugin:** `@tailwindcss/postcss` (package: `@tailwindcss/postcss`)
-    *   **Vite Plugin:** `@tailwindcss/vite` (package: `@tailwindcss/vite`) - Recommended for Vite projects due to optimized performance and DX.
+    -   **CLI:** `npx @tailwindcss/cli ...` (package: `@tailwindcss/cli`)
+    -   **PostCSS Plugin:** `@tailwindcss/postcss` (package: `@tailwindcss/postcss`)
+    -   **Vite Plugin:** `@tailwindcss/vite` (package: `@tailwindcss/vite`) - Recommended for Vite projects due to optimized performance and DX.
 3.  **Internalized Processing:**
-    *   `postcss-import` and `autoprefixer` are generally no longer required as separate dependencies. Tailwind v4 handles CSS bundling and vendor prefixing (via Lightning CSS) internally.
+    -   `postcss-import` and `autoprefixer` are generally no longer required as separate dependencies. Tailwind v4 handles CSS bundling and vendor prefixing (via Lightning CSS) internally.
 
 ### III. Key Migration Considerations & API Changes (v3 -> v4)
 
 1.  **Configuration File Shift:**
-    *   While `tailwind.config.js` can still be used for plugin definitions or complex setups (loaded via `@config "path/to/config.js";`), theme customization (colors, spacing, fonts, breakpoints) should primarily occur in CSS via `@theme`.
-    *   The `content` array for source file scanning is still primarily configured via JS config if used, or Tailwind attempts automatic detection. Use `@source` in CSS for explicit path additions/exclusions.
+    -   While `tailwind.config.js` can still be used for plugin definitions or complex setups (loaded via `@config "path/to/config.js";`), theme customization (colors, spacing, fonts, breakpoints) should primarily occur in CSS via `@theme`.
+    -   The `content` array for source file scanning is still primarily configured via JS config if used, or Tailwind attempts automatic detection. Use `@source` in CSS for explicit path additions/exclusions.
 2.  **Utility Deprecations & Renames:**
-    *   The `npx @tailwindcss/upgrade` tool is highly recommended and automates most of this.
-    *   Opacity syntax is now consistently `bg-black/50` (no more `bg-opacity-50`).
-    *   Scales for `shadow`, `rounded`, and `blur` have been normalized (e.g., `shadow` -> `shadow-sm`, `shadow-sm` -> `shadow-xs`).
-    *   `ring` default width is now `1px` (was `3px`); use `ring-3` for the old default.
+    -   The `npx @tailwindcss/upgrade` tool is highly recommended and automates most of this.
+    -   Opacity syntax is now consistently `bg-black/50` (no more `bg-opacity-50`).
+    -   Scales for `shadow`, `rounded`, and `blur` have been normalized (e.g., `shadow` -> `shadow-sm`, `shadow-sm` -> `shadow-xs`).
+    -   `ring` default width is now `1px` (was `3px`); use `ring-3` for the old default.
 3.  **Default Value Adjustments:**
-    *   Default border color is now `currentColor`. Explicitly add color classes like `border-gray-200` if you relied on the v3 default gray.
-    *   Default ring color is `currentColor` (was `blue-500`).
+    -   Default border color is now `currentColor`. Explicitly add color classes like `border-gray-200` if you relied on the v3 default gray.
+    -   Default ring color is `currentColor` (was `blue-500`).
 4.  **Selector Modifications:**
-    *   `space-x-*`/`space-y-*` utilities now use `margin-bottom`/`margin-right` on `:not(:last-child)` for performance. This might affect inline elements or layouts with existing tweaked margins. Flex/grid `gap` is often a better alternative.
-    *   Variant stacking order is now left-to-right (e.g., `dark:md:hover:bg-red-500`) for CSS-like consistency.
+    -   `space-x-*`/`space-y-*` utilities now use `margin-bottom`/`margin-right` on `:not(:last-child)` for performance. This might affect inline elements or layouts with existing tweaked margins. Flex/grid `gap` is often a better alternative.
+    -   Variant stacking order is now left-to-right (e.g., `dark:md:hover:bg-red-500`) for CSS-like consistency.
 5.  **Custom Utility Definition:**
-    *   `@utility` directive replaces `@layer components` or `@layer utilities` for defining custom, variant-aware utility classes. This ensures proper integration with Tailwind's engine and cascade layers.
+    -   `@utility` directive replaces `@layer components` or `@layer utilities` for defining custom, variant-aware utility classes. This ensures proper integration with Tailwind's engine and cascade layers.
         ```css
         @utility btn-primary {
           background-color: var(--color-brand-500);
           /* ... */
         }
         ```
-    *   Functional utilities (e.g., `tab-*` matching `tab-2`, `tab-github`) are defined using `@utility` with a `--value()` function to parse arguments and match theme keys or arbitrary values.
+    -   Functional utilities (e.g., `tab-*` matching `tab-2`, `tab-github`) are defined using `@utility` with a `--value()` function to parse arguments and match theme keys or arbitrary values.
 6.  **`@apply` in Scoped Styles (Vue SFCs, Svelte, CSS Modules):**
-    *   Due to isolated processing of these style blocks by build tools, theme variables, custom utilities, and variants defined in global CSS are not automatically available.
-    *   Use `@reference "../path/to/your/main.css";` *inside* the scoped style block to make these available without duplicating CSS output.
-    *   Alternatively, directly use CSS variables (`var(--color-brand-500)`) instead of `@apply` for better performance and simpler processing.
+    -   Due to isolated processing of these style blocks by build tools, theme variables, custom utilities, and variants defined in global CSS are not automatically available.
+    -   Use `@reference "../path/to/your/main.css";` _inside_ the scoped style block to make these available without duplicating CSS output.
+    -   Alternatively, directly use CSS variables (`var(--color-brand-500)`) instead of `@apply` for better performance and simpler processing.
 7.  **Prefix Syntax:**
-    *   Utility prefixes are now variant-like: `tw:bg-red-500`. Theme variables in `@theme` remain unprefixed, but generated CSS variables *will* be prefixed (e.g., `--tw-color-red-500`).
+    -   Utility prefixes are now variant-like: `tw:bg-red-500`. Theme variables in `@theme` remain unprefixed, but generated CSS variables _will_ be prefixed (e.g., `--tw-color-red-500`).
 8.  **Arbitrary Value Syntax for CSS Variables:**
-    *   Using CSS variables in arbitrary values now uses parentheses: `bg-(--my-brand-color)` instead of `bg-[--my-brand-color]`. This resolves ambiguity with other arbitrary value types.
+    -   Using CSS variables in arbitrary values now uses parentheses: `bg-(--my-brand-color)` instead of `bg-[--my-brand-color]`. This resolves ambiguity with other arbitrary value types.
 
 ### IV. Advanced Capabilities & Modern CSS Integration
 
 1.  **Enhanced Variant System:**
-    *   Comprehensive support for ARIA attributes (`aria-checked:`, `aria-disabled:`). Custom `aria-*` variants can be defined.
-    *   Data attribute variants (`data-[size=large]:`, `data-active:`).
-    *   `:has()` pseudo-class support via `has-*` variants (e.g., `has-[:focus]:`).
-    *   Child (`*`) and descendant (`**`) combinator variants (e.g., `*:p-2`, `**:data-avatar:rounded-full`).
-    *   `group-*` and `peer-*` variants can now be named for more complex nesting/sibling scenarios (e.g., `group/item`, `peer-checked/opt1:`).
+    -   Comprehensive support for ARIA attributes (`aria-checked:`, `aria-disabled:`). Custom `aria-*` variants can be defined.
+    -   Data attribute variants (`data-[size=large]:`, `data-active:`).
+    -   `:has()` pseudo-class support via `has-*` variants (e.g., `has-[:focus]:`).
+    -   Child (`*`) and descendant (`**`) combinator variants (e.g., `*:p-2`, `**:data-avatar:rounded-full`).
+    -   `group-*` and `peer-*` variants can now be named for more complex nesting/sibling scenarios (e.g., `group/item`, `peer-checked/opt1:`).
 2.  **Container Queries:**
-    *   Enabled via `@container` class on the parent.
-    *   Size-based variants (`@sm:`, `@lg:`, or arbitrary `@min-[475px]:`) style children based on the container's width.
-    *   Named containers (`@container/sidebar`, `@lg/sidebar:`) allow targeting specific ancestor containers.
-    *   Container query length units (`cqw`, `cqi`) can be used in arbitrary values (e.g., `w-[50cqw]`).
+    -   Enabled via `@container` class on the parent.
+    -   Size-based variants (`@sm:`, `@lg:`, or arbitrary `@min-[475px]:`) style children based on the container's width.
+    -   Named containers (`@container/sidebar`, `@lg/sidebar:`) allow targeting specific ancestor containers.
+    -   Container query length units (`cqw`, `cqi`) can be used in arbitrary values (e.g., `w-[50cqw]`).
 3.  **Native CSS Features:**
-    *   Tailwind v4 is built upon and encourages the use of native CSS variables, nesting (processed by Lightning CSS), `color-mix()`, `calc()`, etc.
+    -   Tailwind v4 is built upon and encourages the use of native CSS variables, nesting (processed by Lightning CSS), `color-mix()`, `calc()`, etc.
 
 ### V. Workflow Adjustments & Deprecations
 
 1.  **Preprocessors (Sass/Less/Stylus):**
-    *   Not designed for use with Tailwind v4. Tailwind itself, with its CSS-native features and internal processing via Lightning CSS, fulfills most preprocessor roles.
+    -   Not designed for use with Tailwind v4. Tailwind itself, with its CSS-native features and internal processing via Lightning CSS, fulfills most preprocessor roles.
 2.  **`theme()` Function in CSS:**
-    *   Deprecated. Use `var(--css-variable-name)` instead. For media queries where `var()` isn't supported, `theme(--breakpoint-xl)` (using the CSS variable name) can be used.
+    -   Deprecated. Use `var(--css-variable-name)` instead. For media queries where `var()` isn't supported, `theme(--breakpoint-xl)` (using the CSS variable name) can be used.
 3.  **`corePlugins` in JS Config:**
-    *   Disabling core plugins via JS config is no longer supported. Manage utility generation by not using unwanted classes or explicitly excluding them if necessary via `@source not inline(...)`.
+    -   Disabling core plugins via JS config is no longer supported. Manage utility generation by not using unwanted classes or explicitly excluding them if necessary via `@source not inline(...)`.
 
 Tailwind CSS v4 represents a leaner, faster, and more CSS-idiomatic approach. The upgrade tool (`npx @tailwindcss/upgrade`) is crucial for v3 projects. For new projects, understanding the CSS-first configuration and modern CSS dependencies is key.

--- a/docs/tailwind-v4-guide.md
+++ b/docs/tailwind-v4-guide.md
@@ -1352,9 +1352,9 @@ npm list | grep postcss
 ## v3 to v4 Migration Checklist
 
 ### Pre-Migration
-- [ ] Backup your project
-- [ ] Ensure Node.js 20+ is installed
-- [ ] Check browser support requirements (Safari 16.4+, Chrome 111+, Firefox 128+)
+- [] Backup your project
+- [] Ensure Node.js 20+ is installed
+- [] Check browser support requirements (Safari 16.4+, Chrome 111+, Firefox 128+)
 
 ### Automated Migration
 ```bash
@@ -1362,21 +1362,21 @@ npx @tailwindcss/upgrade@next
 ```
 
 ### Manual Verification
-- [ ] Replace `@tailwind` directives with `@import "tailwindcss"`
-- [ ] Move `tailwind.config.js` content to CSS `@theme`
-- [ ] Update deprecated utility classes
-- [ ] Test container queries functionality
-- [ ] Verify custom component styles
-- [ ] Check 3D transform support
-- [ ] Test mask utilities if used
-- [ ] Validate color consistency (OKLCH vs RGB)
+- [] Replace `@tailwind` directives with `@import "tailwindcss"`
+- [] Move `tailwind.config.js` content to CSS `@theme`
+- [] Update deprecated utility classes
+- [] Test container queries functionality
+- [] Verify custom component styles
+- [] Check 3D transform support
+- [] Test mask utilities if used
+- [] Validate color consistency (OKLCH vs RGB)
 
 ### Testing
-- [ ] Test in all target browsers
-- [ ] Verify responsive design still works
-- [ ] Check dark mode functionality
-- [ ] Test custom animations
-- [ ] Validate accessibility features
+- [] Test in all target browsers
+- [] Verify responsive design still works
+- [] Check dark mode functionality
+- [] Test custom animations
+- [] Validate accessibility features
 
 ## Production-Ready Component Patterns
 

--- a/src/app/data/explore.routes.ts
+++ b/src/app/data/explore.routes.ts
@@ -249,5 +249,5 @@ export const curatedRouteMaps: Record<string, string> = {
   "after-dark": walkRouteMap3,
 };
 
-export type { Route, RouteCollection, CommunityPick, TrendingRouteHighlight };
+export type { CommunityPick, Route, RouteCollection, TrendingRouteHighlight };
 export type ExploreRouteBadgeId = BadgeId;

--- a/src/app/features/explore/explore-sections.tsx
+++ b/src/app/features/explore/explore-sections.tsx
@@ -331,5 +331,5 @@ export function CuratedCollectionsList({
   );
 }
 
-export { CommunityPickPanel, TrendingRoutesList };
 export type { TrendingRouteCard } from "./explore-trending";
+export { CommunityPickPanel, TrendingRoutesList };

--- a/tests/fluent-quick-walk-duration.test.ts
+++ b/tests/fluent-quick-walk-duration.test.ts
@@ -40,7 +40,7 @@ describe("quick walk duration Fluent message", () => {
     const bundle = new FluentBundle("it");
     bundle.addResource(new FluentResource(source));
     const message = bundle.getMessage("quick-walk-duration-format");
-    if (!message || !message.value) throw new Error("missing message");
+    if (!message?.value) throw new Error("missing message");
     const pattern = message.value;
     expect(() => bundle.formatPattern(pattern)).toThrow();
   });

--- a/tests/semantic-lint-workflow.test.ts
+++ b/tests/semantic-lint-workflow.test.ts
@@ -1,0 +1,27 @@
+/** @file Guards the semantic lint workflow wiring that CI executes. */
+import { describe, expect, it } from "bun:test";
+
+const workflowPath = ".github/workflows/semantic-lint.yml";
+const setupUvPinnedAction = "astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78";
+
+const readWorkflow = () => Bun.file(workflowPath).text();
+
+describe("semantic lint workflow", () => {
+  it("runs the semantic gate after installing uvx support", async () => {
+    const workflow = await readWorkflow();
+    const setupUvStepIndex = workflow.indexOf(setupUvPinnedAction);
+    const semanticGateIndex = workflow.indexOf("- run: bun semantic");
+
+    expect(setupUvStepIndex).toBeGreaterThanOrEqual(0);
+    expect(semanticGateIndex).toBeGreaterThan(setupUvStepIndex);
+    expect(workflow).toContain("bun install --frozen-lockfile");
+  });
+
+  it("pins setup-uv to a full commit SHA while recording the release tag", async () => {
+    const workflow = await readWorkflow();
+
+    expect(workflow).toContain("# astral-sh/setup-uv v7");
+    expect(workflow).toContain(`- uses: ${setupUvPinnedAction}`);
+    expect(workflow).not.toContain("uses: astral-sh/setup-uv@v7");
+  });
+});


### PR DESCRIPTION
## Summary

This branch restores the semantic lint gate that CI stopped enforcing when the `bun semantic` step was commented out pending the semantic-class migration. The required `lint` check had been passing trivially ever since: it installed dependencies and ran nothing.

The semantic suite (`biome ci`, class-list length and near-duplicate checks, the semgrep semantic rules, and stylelint) is re-enabled. The workflow also installs `uv`, because `semantic:lint` invokes semgrep via `uvx` and the bun-only runner did not provide it.

Review feedback is addressed by pinning `astral-sh/setup-uv` to the full v7 commit SHA, adding a workflow smoke test for the `setup-uv`/`bun semantic` ordering, and documenting the local/CI `uvx semgrep` dependency in `docs/developers-guide.md`.

## Review walkthrough

- `.github/workflows/semantic-lint.yml` restores `bun semantic`, installs `uv` before that step, and pins `astral-sh/setup-uv` to `37802adc94f370d6bfd71619e3f0bf239e1f3b78` with the v7 tag retained in a comment.
- `tests/semantic-lint-workflow.test.ts` smoke-tests that the workflow installs the pinned `setup-uv` action before invoking the semantic gate.
- `docs/developers-guide.md` documents the semantic lint gate, its component checks, and the `uvx semgrep` runtime requirement.
- `Makefile` adds wrappers for the requested local gates: `make check-fmt`, `make lint`, `make typecheck`, and `make test`.
- Formatting/import cleanups were applied where the newly enforced gates required them.

## Validation

- `make check-fmt`: pass
- `make lint`: pass
- `make typecheck`: pass
- `make test`: pass (204 tests)
- `bun semantic`: pass (Semgrep 6 rules, 0 findings)
- `actionlint .github/workflows/semantic-lint.yml`: pass
- `mbake validate Makefile`: pass

## Notes

- Semgrep reports scanning only 1 file due to its `--include` pattern behaviour; that matches how the suite runs locally and is unchanged here.
- The semantic duplicate-class checker still prints advisory findings, but exits 0 as part of the existing gate behaviour.

## References

- Lody session: https://lody.ai/leynos/sessions/be90c7ce-c9fe-4eff-a947-53ebb35c6719
